### PR TITLE
Corrections and tweaks to the orientable manifolds.

### DIFF
--- a/E1/E1.tex
+++ b/E1/E1.tex
@@ -87,7 +87,7 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=12pt, yshift=-26pt
+	anchor=north east, xshift=16pt, yshift=-16pt
 ]{\textcolor{black}{\(\mathbf{T_{A_{3}}}\)}};
 
 \draw[vector help] (O) -- (D);
@@ -110,7 +110,7 @@
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
 \pic[draw, -, angle radius=4mm, angle eccentricity=1.3, "\(\alpha\)"] {angle = A--O--B};
-\pic[draw, -, angle radius=9mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O3};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)"] {angle = D--O--C};
 \pic[draw, -, angle radius=7mm, angle eccentricity=1.25, "\(\gamma\)"] {angle = A--O--D};
 
 \end{tikzpicture}

--- a/E12/E12.tex
+++ b/E12/E12.tex
@@ -57,8 +57,8 @@
 
 \coordinate (A) at (2.7, 0, 0);
 \coordinate (B) at (0, 2.6, 0);
-\coordinate (C) at (1.1, 2.5, 2.8);
-\coordinate (D) at (1.1, 0, 2.8);
+\coordinate (C) at (1.1, 2.8, 3.3);
+\coordinate (D) at (1.1, 2.8, 0);
 
 \path (O) + (\smallvecx, 0, 0) coordinate (O1);
 \path (O) + (0, \smallvecx, 0) coordinate (O2);
@@ -77,7 +77,7 @@
 \path (C) + (0, 0, \smallvecx) coordinate (C3);
 
 \path (C3) + (\smallvecx, 0, 0) coordinate (C3x);
-\path (C3) + (-\smallvecx, 0, 0) coordinate (C3y);
+\path (C3) + (-\smallvecx, 0, -\smallvecx) coordinate (C3y);
 
 \draw[axis] (0, 0, 0) -- (4, 0, 0) node[anchor=north east]{$x$};
 \draw[axis] (0, 0, 0) -- (0, 4, 0) node[anchor=north west]{$y$};
@@ -92,7 +92,7 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=10pt, yshift=-4pt
+	anchor=north east, xshift=-12pt, yshift=1pt
 ]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector help] (O) -- (D);
@@ -110,10 +110,12 @@
 \draw[vector guide, dashed, arrowgreen] (C) -- (C2);
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
-\pic[draw, -, angle radius=4mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--D};
-\pic[draw, -, angle radius=8mm, angle eccentricity=1.25, "\(\gamma\)"] {angle = O3--O--D};
+%\pic[draw, -, angle radius=4mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--D};
+%\pic[draw, -, angle radius=8mm, angle eccentricity=1.25, "\(\gamma\)"] {angle = O3--O--D};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)", pic text options={shift={(2pt, 4pt)}}] {angle = D--O--C};
+\pic[draw, -, angle radius=7mm, angle eccentricity=1.45, "\(\gamma\)"] {angle = A--O--D};
 
-\pic[draw, -to, angle radius=2mm, angle eccentricity=1, "\(\pi\)", pic text options={shift={(8pt, 2pt)}}] {angle = C3x--C3--C3y};
+\pic[draw, -to, angle radius=3mm, angle eccentricity=1, "\(\pi\)", pic text options={shift={(9pt, 8pt)}}] {angle = C3x--C3--C3y};
 
 \end{tikzpicture}
 \end{document}

--- a/E16i/E16i.tex
+++ b/E16i/E16i.tex
@@ -62,7 +62,7 @@
 \draw[
 	vector, Violet
 ] (O) -- (C) node [
-	anchor=north east, xshift=8pt, yshift=-26pt
+	anchor=north east, xshift=8pt, yshift=-6pt
 ]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector guide, arrowred] (O) -- (O1);
@@ -73,7 +73,7 @@
 \draw[vector guide, dashed, arrowgreen] (C) -- (C2);
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
-\pic[draw, -, angle radius=7mm, angle eccentricity=1.25, "\(\beta\)"] {angle = O3--O--C};
+\pic[draw, -, angle radius=7mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O1};
 
 \pic[draw, -to, angle radius=3mm, angle eccentricity=1.9, "\(\sfrac{2 \pi p\!}{q}\)", pic text options={shift={(16pt, 8pt)}}] {angle = C3x--C3--C3y};
 

--- a/E2/E2.tex
+++ b/E2/E2.tex
@@ -69,7 +69,7 @@
 \path (C) + (0, 0, \smallvecx) coordinate (C3);
 
 \path (C3) + (\smallvecx, 0, 0) coordinate (C3x);
-\path (C3) + (-\smallvecx, 0, 0) coordinate (C3y);
+\path (C3) + (-\smallvecx, 0, -\smallvecx) coordinate (C3y);
 
 \draw[axis] (0, 0, 0) -- (4, 0, 0) node[anchor=north east]{$x$};
 \draw[axis] (0, 0, 0) -- (0, 4, 0) node[anchor=north west]{$y$};
@@ -90,8 +90,8 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=12pt, yshift=-26pt
-]{\textcolor{black}{\(\mathbf{T_{A_{3}}}\)}};
+	anchor=north east, xshift=-1pt, yshift=1pt
+]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector help] (O) -- (D);
 \draw[vector help] (C) -- (D);
@@ -113,10 +113,10 @@
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
 \pic[draw, -, angle radius=4mm, angle eccentricity=1.3, "\(\alpha\)"] {angle = A--O--B};
-\pic[draw, -, angle radius=9mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O3};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)"] {angle = D--O--C};
 \pic[draw, -, angle radius=7mm, angle eccentricity=1.25, "\(\gamma\)"] {angle = A--O--D};
 
-\pic[draw, -to, angle radius=2mm, angle eccentricity=1, "\(\pi\)", pic text options={shift={(8pt, 5pt)}}] {angle = C3x--C3--C3y};
+\pic[draw, -to, angle radius=3mm, angle eccentricity=1, "\(\pi\)", pic text options={shift={(9pt, 8pt)}}] {angle = C3x--C3--C3y};
 
 \end{tikzpicture}
 \end{document}

--- a/E3/E3.tex
+++ b/E3/E3.tex
@@ -98,7 +98,7 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=8pt, yshift=-26pt
+	anchor=north east, xshift=-1pt, yshift=1pt
 ]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector help] (O) -- (D);
@@ -120,10 +120,10 @@
 \draw[vector guide, dashed, arrowgreen] (C) -- (C2);
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
-\pic[draw, -, angle radius=9mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O3};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)"] {angle = D--O--C};
 \pic[draw, -, angle radius=4mm, angle eccentricity=1.45, "\(\gamma\)"] {angle = A--O--D};
 
-\pic[draw, -to, angle radius=2mm, angle eccentricity=1, "\(\sfrac{\pi}{2}\)", pic text options={shift={(12pt, 2pt)}}] {angle = C3x--C3--C3y};
+\pic[draw, -to, angle radius=3mm, angle eccentricity=1, "\(\sfrac{\pi}{2}\)", pic text options={shift={(12pt, 6pt)}}] {angle = C3x--C3--C3y};
 
 \end{tikzpicture}
 \end{document}

--- a/E4/E4.tex
+++ b/E4/E4.tex
@@ -99,7 +99,7 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=8pt, yshift=-26pt
+	anchor=north east, xshift=-1pt, yshift=1pt
 ]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector help] (O) -- (D);
@@ -122,7 +122,7 @@
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
 \pic[draw, -, angle radius=4mm, angle eccentricity=1.4, "\(\sfrac{2 \pi\!}{3}\)", pic text options={shift={(10pt, 1pt)}}] {angle = A--O--B};
-\pic[draw, -, angle radius=9mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O3};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)", pic text options={shift={(2pt, 4pt)}}] {angle = D--O--C};
 \pic[draw, -, angle radius=7mm, angle eccentricity=1.45, "\(\gamma\)"] {angle = A--O--D};
 
 \pic[draw, -to, angle radius=3mm, angle eccentricity=1.9, "\(\sfrac{2 \pi\!}{3}\)", pic text options={shift={(14pt, 8pt)}}] {angle = C3x--C3--C3y};

--- a/E5/E5.tex
+++ b/E5/E5.tex
@@ -202,7 +202,7 @@
 \draw[
 	vector, Brown
 ] (O) -- (C) node [
-	anchor=north east, xshift=8pt, yshift=-26pt
+	anchor=north east, xshift=-1pt, yshift=1pt
 ]{\textcolor{black}{\(\mathbf{T_{B}}\)}};
 
 \draw[vector help] (O) -- (D);
@@ -225,10 +225,10 @@
 \draw[vector guide, densely dotted, arrowblue] (C) -- (C3);
 
 \pic[draw, -, angle radius=4mm, angle eccentricity=1.4, "\(\sfrac{2 \pi\!}{3}\)", pic text options={shift={(10pt, 1pt)}}] {angle = A--O--B};
-\pic[draw, -, angle radius=9mm, angle eccentricity=1.25, "\(\beta\)"] {angle = C--O--O3};
+\pic[draw, -, angle radius=3mm, angle eccentricity=1.4, "\(\beta\)", pic text options={shift={(2pt, 4pt)}}] {angle = D--O--C};
 \pic[draw, -, angle radius=7mm, angle eccentricity=1.45, "\(\gamma\)"] {angle = A--O--D};
 
-\pic[draw, -to, angle radius=3mm, angle eccentricity=1.9, "\(\sfrac{\pi\!}{3}\)", pic text options={shift={(14pt, 5pt)}}] {angle = C3x--C3--C3y};
+\pic[draw, -to, angle radius=3mm, angle eccentricity=1.9, "\(\sfrac{\pi\!}{3}\)", pic text options={shift={(14pt, 8pt)}}] {angle = C3x--C3--C3y};
 
 \end{tikzpicture}
 \end{document}


### PR DESCRIPTION
Following up on one of our discussions I went ahead and corrected/tweaked the figures for the orientable spaces.

Main corrections:
 - E1-E5, E12: beta is measured from the xy-plane, not the z-axis
 - E2: TA3 -> TB
 - E12: gamma is measured from the x-axis in the xy-plane
 - E16i: beta is measured from the x-axis
  
 Main tweaks: 
 - Move the TB label to be above the vector. It no longer intersects the vertical dashed-dotted line.
 - Modify the rotation arc to not intersect the arrow in the z-direction (blue arrow). (Done in a few of the figures.)

Note that E12 really is identical to E2 but with TA2 removed and TA1 labeled as TA. This is currently not the case: E2 and E12 have been separately drawn with different choices for the orientation of TB and the yz-plane shaded in E12.

I did not completely change E12, but it could be an exact copy of E2 with the changes noted above.